### PR TITLE
Making name changes to config according to guidelines

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/AdminCLIRunner.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/AdminCLIRunner.java
@@ -38,10 +38,10 @@ public final class AdminCLIRunner {
      * <p>
      * To speed up setup, create a config.properties file and put the following properties (at a minimum):
      * <p>
-     * pravegaservice.containerCount={number of containers}
-     * pravegaservice.zkURL={host:port for ZooKeeper}
-     * cli.controllerRestUri={host:port for a Controller REST API endpoint}
-     * bookkeeper.bkLedgerPath={path in ZooKeeper where BookKeeper stores Ledger metadata}
+     * pravegaservice.container.count={number of containers}
+     * pravegaservice.zk.connect.uri={host:port for ZooKeeper}
+     * cli.controller.rest.uri={host:port for a Controller REST API endpoint}
+     * bookkeeper.ledger.path={path in ZooKeeper where BookKeeper stores Ledger metadata}
      * <p>
      * This program can be executed in two modes. First, the "interactive mode", in which you may want to point to a
      * config file that contains the previous mandatory configuration parameters:
@@ -52,7 +52,7 @@ public final class AdminCLIRunner {
      *
      * Second, this program can be executed in "batch mode" to execute a single command. To this end, you need to pass
      * as program argument the command to execute and as properties the configuration parameters (-D flag):
-     * ./pravega-cli controller list-scopes -Dpravegaservice.containerCount={value} -Dpravegaservice.zkURL={value} ...
+     * ./pravega-cli controller list-scopes -Dpravegaservice.container.count={value} -Dpravegaservice.zk.connect.uri={value} ...
      *
      * @param args Arguments.
      * @throws Exception If one occurred.

--- a/cli/admin/src/main/java/io/pravega/cli/admin/utils/CLIControllerConfig.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/utils/CLIControllerConfig.java
@@ -24,12 +24,12 @@ public final class CLIControllerConfig {
         SEGMENTSTORE, ZOOKEEPER
     }
 
-    private static final Property<String> CONTROLLER_REST_URI = Property.named("controllerRestUri", "http://localhost:9091");
-    private static final Property<String> CONTROLLER_GRPC_URI = Property.named("controllerGrpcUri", "tcp://localhost:9090");
-    private static final Property<Boolean> AUTH_ENABLED = Property.named("authEnabled", false);
-    private static final Property<String> CONTROLLER_USER_NAME = Property.named("userName", "");
-    private static final Property<String> CONTROLLER_PASSWORD = Property.named("password", "");
-    private static final Property<String> METADATA_BACKEND = Property.named("metadataBackend", MetadataBackends.SEGMENTSTORE.name());
+    private static final Property<String> CONTROLLER_REST_URI = Property.named("controller.rest.uri", "http://localhost:9091");
+    private static final Property<String> CONTROLLER_GRPC_URI = Property.named("controller.grpc.uri", "tcp://localhost:9090");
+    private static final Property<Boolean> AUTH_ENABLED = Property.named("security.auth.enable", false);
+    private static final Property<String> CONTROLLER_USER_NAME = Property.named("security.auth.credentials.username", "");
+    private static final Property<String> CONTROLLER_PASSWORD = Property.named("security.auth.credentials.password", "");
+    private static final Property<String> METADATA_BACKEND = Property.named("store.metadata.backend", MetadataBackends.SEGMENTSTORE.name());
 
     private static final String COMPONENT_CODE = "cli";
 

--- a/cli/admin/src/main/resources/config.properties
+++ b/cli/admin/src/main/resources/config.properties
@@ -9,21 +9,21 @@
 #
 
 # Config for CLI credentials (at the moment, Controller auth is only supported).
-cli.authEnabled=false
-cli.userName=admin
-cli.password=1111_aaaa
+cli.security.auth.enable=false
+cli.security.auth.credentials.username=admin
+cli.security.auth.credentials.password=1111_aaaa
 
 # Config for CLI Controller REST/GRPC endpoints.
-cli.controllerRestUri=http://localhost:10080
-cli.controllerGrpcUri=tcp://localhost:9090
-cli.metadataBackend=segmentstore
+cli.controller.rest.uri=http://localhost:10080
+cli.controller.grpc.uri=tcp://localhost:9090
+cli.store.metadata.backend=segmentstore
 
 # General configuration for the Pravega cluster at hand.
-pravegaservice.clusterName=pravega
-pravegaservice.containerCount=4
+pravegaservice.cluster.name=pravega
+pravegaservice.container.count=4
 
 # Config for Zookeeper service.
-pravegaservice.zkURL=localhost:2181
+pravegaservice.zk.connect.uri=localhost:2181
 
 # Config for Bookkeeper commands.
-bookkeeper.bkLedgerPath=/pravega/pravega/bookkeeper/ledgers
+bookkeeper.ledger.path=/pravega/pravega/bookkeeper/ledgers

--- a/cli/admin/src/test/java/io/pravega/cli/admin/AbstractAdminCommandTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/AbstractAdminCommandTest.java
@@ -33,10 +33,10 @@ public abstract class AbstractAdminCommandTest {
         SETUP_UTILS.startAllServices();
         STATE.set(new AdminCommandState());
         Properties pravegaProperties = new Properties();
-        pravegaProperties.setProperty("cli.controllerRestUri", SETUP_UTILS.getControllerRestUri().toString());
-        pravegaProperties.setProperty("cli.controllerGrpcUri", SETUP_UTILS.getControllerUri().toString());
-        pravegaProperties.setProperty("pravegaservice.zkURL", SETUP_UTILS.getZkTestServer().getConnectString());
-        pravegaProperties.setProperty("pravegaservice.containerCount", "4");
+        pravegaProperties.setProperty("cli.controller.rest.uri", SETUP_UTILS.getControllerRestUri().toString());
+        pravegaProperties.setProperty("cli.controller.grpc.uri", SETUP_UTILS.getControllerUri().toString());
+        pravegaProperties.setProperty("pravegaservice.zk.connect.uri", SETUP_UTILS.getZkTestServer().getConnectString());
+        pravegaProperties.setProperty("pravegaservice.container.count", "4");
         STATE.get().getConfigBuilder().include(pravegaProperties);
     }
 

--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -42,9 +42,9 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
 
         STATE.set(new AdminCommandState());
         Properties bkProperties = new Properties();
-        bkProperties.setProperty("pravegaservice.containerCount", "4");
-        bkProperties.setProperty("pravegaservice.zkURL", zkUtil.getZooKeeperConnectString());
-        bkProperties.setProperty("bookkeeper.bkLedgerPath", "/ledgers");
+        bkProperties.setProperty("pravegaservice.container.count", "4");
+        bkProperties.setProperty("pravegaservice.zk.connect.uri", zkUtil.getZooKeeperConnectString());
+        bkProperties.setProperty("bookkeeper.ledger.path", "/ledgers");
         STATE.get().getConfigBuilder().include(bkProperties);
     }
 


### PR DESCRIPTION
Signed-off-by: anirudhkovuru <anirudhkovuru@gmail.com>

**Change log description**  

- Made changes to the names of the properties in the `config.properties`. 

**Purpose of the change**  
To make sure the property names comply with the new [Configuration Naming Guidelines](https://github.com/pravega/pravega/wiki/Configuration-Naming-Guidelines).

**What the code does**  

- The `config.properties` has updated names.
- The `CLIControllerConfig` class has been changed to parse the new naming.
- The test classes of `BookkeeperCommandsTest` and `AbstractAdminCommandTest` have also been changed to reflect the new property names

**How to verify it**  
The `BookkeeperCommandsTest`, `ControllerCommandsTest` and `ClusterCommandsTest` must all pass.
